### PR TITLE
chore: add typescript-eslint umbrella package to peerDependencies for compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@eslint/js": "^9.0.0",
     "eslint": "^9.0.0",
     "globals": "^14.0.0",
+    "typescript-eslint": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "eslint-plugin-react": "^7.37.5",


### PR DESCRIPTION
Some consumers import the unscoped 'typescript-eslint' package (an umbrella package that re-exports @typescript-eslint/parser and @typescript-eslint/eslint-plugin). Adding it as a peerDependency ensures the package can import 'typescript-eslint' successfully for now while we keep explicit scoped peerDependencies as well.

This is done for compatibility; consider updating the code to import the scoped packages directly in a follow-up to avoid needing this umbrella package.

🤖 Generated with [opencode](https://opencode.ai)